### PR TITLE
Update dep-review.yml

### DIFF
--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -1,6 +1,9 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
@@ -8,4 +11,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
       - name: 'Dependency Review'
-        uses: dsp-testing/dependency-review-action@main
+        uses: actions/dependency-review-action@v1


### PR DESCRIPTION
This PR updates the `dep-review.yml` workflow to use the post-GA URL and version. Pushing as a draft, will mark as ready for review once we've launched.

Tracking issue: https://github.com/github/dependency-graph/issues/1019